### PR TITLE
Columns description as optional scd argument

### DIFF
--- a/definitions/example.js
+++ b/definitions/example.js
@@ -15,6 +15,8 @@ const { updates, view } = scd("source_data_scd", {
   },
   // Any tags that will be added to actions.
   tags: ["slowly-changing-dimensions"],
+  // Optional documentation of table columns
+  columns: {user_id: "User ID", some_field: "Data Field", updated_at: "Timestamp for updates"},
   // Any configuration parameters to apply to the incremental table that will be created.
   incrementalConfig: {
     bigquery: {

--- a/index.js
+++ b/index.js
@@ -3,12 +3,13 @@
  */
 module.exports = (
   name,
-  { uniqueKey, timestamp, source, tags, incrementalConfig }
+  { uniqueKey, timestamp, source, tags, incrementalConfig, columns = {} }
 ) => {
   // Create an incremental table with just pure updates, for a full history of the table.
   const updates = publish(`${name}_updates`, {
     type: "incremental",
     tags,
+    columns,
     ...incrementalConfig,
   }).query(
     (ctx) => `
@@ -25,6 +26,7 @@ module.exports = (
     type: "view",
     tags,
     columns: {
+      ...columns,
       scd_valid_from: `The timestamp from which this row is valid for the given ${uniqueKey}.`,
       scd_valid_to: `The timestamp until which this row is valid for the given ${uniqueKey}, or null if this it the latest value.`,
     },


### PR DESCRIPTION
I've added optional argument "columns" to allow description of table columns in scd-tables.