### PR TITLE
Implemented hash comparison for SCD Type 2 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .df-credentials.json
 node_modules/
+.idea/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ scd("source_data_scd", {
   // A field that stores a timestamp or date of when the row was last changed.
   timestamp: "updated_at",
   // The source table to build slowly changing dimensions from.
-  source: {
+    hash: "hash_value",
+    // A field that stores the hash value of the fields that we want to track changes in
+    source: {
     schema: "dataform_scd_example",
     name: "source_data",
   },

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ scd("source_data_scd", {
   uniqueKey: "user_id",
   // A field that stores a timestamp or date of when the row was last changed.
   timestamp: "updated_at",
-  // The source table to build slowly changing dimensions from.
-    hash: "hash_value", // OPTIONAL
     // A field that stores the hash value of the fields that we want to track changes in. If you do not want to use the hash comparison, you may omit this field or set it to null
+    hash: "hash_value", // OPTIONAL
+    // The source table to build slowly changing dimensions from.
     source: {
       schema: "dataform_scd_example",
       name: "source_data",

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ scd("source_data_scd", {
   // A field that stores a timestamp or date of when the row was last changed.
   timestamp: "updated_at",
   // The source table to build slowly changing dimensions from.
-    hash: "hash_value",
-    // A field that stores the hash value of the fields that we want to track changes in
+    hash: "hash_value", // OPTIONAL
+    // A field that stores the hash value of the fields that we want to track changes in. If you do not want to use the hash comparison, you may omit this field or set it to null
     source: {
-    schema: "dataform_scd_example",
-    name: "source_data",
+      schema: "dataform_scd_example",
+      name: "source_data",
   },
   // Any configuration parameters to apply to the incremental table that will be created.
   incrementalConfig: {
@@ -45,6 +45,12 @@ For more advanced customization of outputs, see the [example.js](https://github.
 ### Scheduling
 
 Slowly changing dimensions can only by updated as quickly as these models are run. These models should typically be scheduled to run every day or every hour, depending on the granularity of changes you want to capture.
+
+### Hash comparison option
+
+Depending on your data update method, you may want to use the hash field option to compare rows on each execution and only add the ones that have been changed or added. To do this, please make sure your table contains a hash field created using the hash function of your choice. You can find a list of the hash functions available in BigQuery [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions). On each incremental run, the query will compare the hashes for each unique identifier to the ones in the updated table. It will only keep the rows where the hash has changed or where the row ID is not found in the current data.
+
+If you do not want to use the hash comparison, simply omit the hash parameter from the config file or set it to `null`. If you do this, all rows with an updated timestamp will be added to the `{name}_updates` table, even if the data did not otherwise change.
 
 ## Data models
 

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -2,7 +2,7 @@ const scd = require("dataform-scd");
 /**
  * Create an SCD table on top of the fake table defined in source_data.sqlx.
  */
-const { updates, view } = scd("customer_scd", {
+const { updates, view } = scd("source_data_scd", {
   // A unique identifier for rows in the table.
   uniqueKey: "user_id",
   // A field that stores a timestamp or date of when the row was last changed.

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -1,13 +1,14 @@
-const scd = require("../index");
-
+const scd = require("dataform-scd");
 /**
  * Create an SCD table on top of the fake table defined in source_data.sqlx.
  */
-const { updates, view } = scd("source_data_scd", {
+const { updates, view } = scd("customer_scd", {
   // A unique identifier for rows in the table.
   uniqueKey: "user_id",
   // A field that stores a timestamp or date of when the row was last changed.
   timestamp: "updated_at",
+  // A field that stores the hash value of the fields that we want to track changes in
+  hash: "hash_value",
   // The source table to build slowly changing dimensions from.
   source: {
     schema: "dataform_scd_example",
@@ -16,7 +17,7 @@ const { updates, view } = scd("source_data_scd", {
   // Any tags that will be added to actions.
   tags: ["slowly-changing-dimensions"],
   // Optional documentation of table columns
-  columns: {user_id: "User ID", some_field: "Data Field", updated_at: "Timestamp for updates"},
+  columns: {user_id: "User ID", some_field: "Data Field", hash_value: "Hash of all fields to compare",updated_at: "Timestamp for updates"},
   // Any configuration parameters to apply to the incremental table that will be created.
   incrementalConfig: {
     bigquery: {

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -1,4 +1,5 @@
-const scd = require("dataform-scd");
+const scd = require("../index");
+
 /**
  * Create an SCD table on top of the fake table defined in source_data.sqlx.
  */

--- a/definitions/example.js
+++ b/definitions/example.js
@@ -8,7 +8,7 @@ const { updates, view } = scd("source_data_scd", {
   uniqueKey: "user_id",
   // A field that stores a timestamp or date of when the row was last changed.
   timestamp: "updated_at",
-  // A field that stores the hash value of the fields that we want to track changes in
+  // A field that stores the hash value of the fields that we want to track changes in. If you do not want to use the hash comparison, you may omit this field or set it to null
   hash: "hash_value",
   // The source table to build slowly changing dimensions from.
   source: {
@@ -29,5 +29,7 @@ const { updates, view } = scd("source_data_scd", {
 
 // Additional customization of the created models can be done by using the returned actions objects.
 updates.config({
+  // You can specify the output schema here if it is different than the default
+  schema: "dataform_scd_example",
   description: "Updates table for SCD",
 });

--- a/definitions/source_data.sqlx
+++ b/definitions/source_data.sqlx
@@ -5,24 +5,32 @@ config {
 WITH example_dataset AS (
   SELECT
     user_id,
-    some_field,
+    field_a,
+    field_b,
     updated_at
   FROM
     (
       SELECT
         1 as user_id,
-        'b' AS some_field,
+        'b' AS field_a,
+        12.3 AS field_b,
         date_add(current_date(), interval 1 day) AS updated_at
     )
   UNION ALL
     (
       SELECT
         2 as user_id,
-        'a' AS some_field,
+        'c' AS field_a,
+        23.4 AS field_b,
         date_add(current_date(), interval 0 day) AS updated_at
     )
 )
 SELECT
-  *
+  *,
+  md5(concat(
+    field_a,
+    cast(field_b AS string)
+    )
+    ) AS hash_value
 FROM
   example_dataset


### PR DESCRIPTION
# Description
In its current state, the SCD plugin creates new entries for all rows present in the table with a new timestamp. In cases where the timestamp is auto-generated, fields will be treated as new even if their values have not changed.
In this PR, I implement row comparison when incrementing. Each row is hashed using the user's hash algorithm of choice, and the incremental table is incremented with only those rows where the new hash does not match the hash of the currently valid entry for the same unique ID.
I am using it in my code, and figured it could be useful to others that are looking to use SCD Type 2 with a hash comparison.

# Changes in the code
- `definitions/example.js`: added the `hash` field to the variable definition and columns list
- `definitions/source_data.sqlx`: updated the example query to generate data with a hash of the `md5` algorithm
- `index.js`: modified the incremental table build to filter for rows where the hash does not match the hash in the current table for the same unique key

# Potential Improvements
Backwards compatibility: it would be good to allow the user to choose whether they want to use a hash or not, and for both the legacy method and the hash method to work with the same code.
I do not normally work with javascript so I'm sure there are possible improvements in the logic as well.