### PR TITLE
Add updates schema in view query ref

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = (
     ${timestamp} as scd_valid_from,
     lead(${timestamp}) over (partition by ${uniqueKey} order by ${timestamp} asc) as scd_valid_to
   from
-    ${ctx.ref(`${name}_updates`)}
+    ${ctx.ref(updates.proto.target.schema, `${name}_updates`)}
   `
   );
 


### PR DESCRIPTION
In my usage scenario, I need to define a schema for my "_update" table. Therefore, it is also crucial to reference this same schema in the query that constitutes the view. I conducted some tests, and the original behavior remained unchanged.