### PR TITLE
Don't ignore values that change and then change back

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = (
           ctx.incremental(), `with ids_to_update as \
         (select ${uniqueKey}, ${hash}  from ${ctx.ref(source)}\
         except distinct \
-        (select ${uniqueKey}, ${hash} from ${ctx.self()}))`
+        (select ${uniqueKey}, any_value(${hash} having max ${timestamp})\
+        from ${ctx.self()} group by ${uniqueKey}))`
       )}
       select * from ${ctx.ref(source)}
       ${ctx.when(

--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ module.exports = (
           ctx.incremental(), `with ids_to_update as \
         (select ${uniqueKey}, ${hash}  from ${ctx.ref(source)}\
         except distinct \
-        (select ${uniqueKey}, any_value(${hash} having max ${timestamp})\
+        (select distinct ${uniqueKey}, first_value(${hash})\
+          over(${uniqueKey} order by ${timestamp} desc\
+            rows between unbounded preceding and unbounded following)\
         from ${ctx.self()} group by ${uniqueKey}))`
       )}
       select * from ${ctx.ref(source)}


### PR DESCRIPTION
This commit should properly account for situations where we are using the hash field to track changes to a couple of fields that may change and then change back to a previous combination (generating the same hash value). The current code only checks whether the present combination appears _anywhere_ in that record's ${name}_updates table, not limiting to the most recent values for that uniqueKey, which I think will cause problems in situations like the following:

Consider a users table and a SCD set up to track changes to the user's language and/or country.

```
uid   name        language    country   updated_date
663   Michael     en          USA       2001-01-01
663   Michael     es          USA       2002-02-02
663   Michael     en          USA       2003-03-03
```

This is a realistic change pattern for real-world data, and if we are tracking the hash of (language, country), we will record the first state, then the second state, and then we will ignore the third because it generates the same hash as the first.

This commit uses `any_value(${hash} having max ${timstamp}) ... group by ${uniqueKey}` to make sure we are only looking at the most recent record in the history table before we compare hashes. 

**One word of caution:** I'm not sure if `any_value` works across all the systems supported by this library and don't have a way of testing it out across all of them. If it doesn't work on other databases there is always the old (and fast) [left outer join method](https://stackoverflow.com/questions/8748986/get-records-with-highest-smallest-whatever-per-group/8749095#8749095). If you are interested in this PR but need me to change this use of `any_value` to a join, I'm happy to do so (but still won't be able to test it myself on the other platforms; only have access to a BigQuery account at work).